### PR TITLE
Updated the hyperclick for variables to work with object variables

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -73,6 +73,9 @@ function scrollToVarDefn( textEditor, varname, range ) {
   var line;
   var n = range.start.row;
   var m;
+  // var re = new RegExp( "\\" + varname + "\s*[^=]?=" );
+  // TH Updated to handle spaces like $this -> varname
+  varname = varname.replace(/\s/g, '\\s*');
   var re = new RegExp( "\\" + varname + "\s*[^=]?=" );
 
   // post-decrement to start looking at line above click
@@ -86,7 +89,11 @@ function scrollToVarDefn( textEditor, varname, range ) {
   if ( m == null || n == -1 )
     return;
 
-  textEditor.setCursorBufferPosition([n, line.indexOf( varname )]);
+
+  // textEditor.setCursorBufferPosition([n, line.indexOf( varname )]);
+  // TH Updated to handle spaces like $this -> varname
+  var varnameIndexOf = line.substring(0).search(re);
+  textEditor.setCursorBufferPosition([n, varnameIndexOf]);
   textEditor.scrollToCursorPosition()
 
 }
@@ -98,10 +105,12 @@ function isVariable( textEditor, range ) {
 
   // can test via console with:
   // atom.workspace.getActiveTextEditor().buffer.lineForRow(11).match(/(require|include)(_once)?.+(['"])(.+)\3/)
-  var matches = line.match(/(\$[a-zA-Z0-9_]+)/g);
-
-  if ( matches == null )
-    return false;
+  // TH Updated to handle spaces like $this -> varname
+  // var matches = line.match(/(\$[a-zA-Z0-9_]+)/g);
+  var matches = line.match(/(\$([a-zA-Z0-9_\s]+)->([\sa-zA-Z0-9_]+\b(?!\()))|(\$[a-zA-Z0-9_]+)/g);
+    if ( matches == null ){
+        return false;
+  }
 
   // multiple variables on same line give multiple matches, so find the
   // right one to jump to
@@ -205,7 +214,6 @@ var singleSuggestionProvider = {
   // wordRegExp: /(['"]).+?\1/,
   getSuggestionForWord(textEditor: TextEditor, text: string, range: Range): HyperclickSuggestion {
     if ( isPHP( textEditor )) {
-
       p = isPath( textEditor, range );
       if ( p ) {
 
@@ -218,7 +226,6 @@ var singleSuggestionProvider = {
           }
         }
       }
-
       t = isVariable( textEditor, range );
       if ( t ) {
         return {
@@ -230,7 +237,6 @@ var singleSuggestionProvider = {
           }
         }
       }
-
       f = isFunction( textEditor, range );
       if ( f ) {
         return {


### PR DESCRIPTION
Updated the hyperclick for variables to work with object variables like $this->varname
Currently works only when $this->varname = 'something'
Doesn't currently work with public $varname
